### PR TITLE
Add support of request rate limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
   ],
   "require": {
     "guzzlehttp/guzzle": "^6.0",
-    "psr/log": "^1.0"
+    "psr/log": "^1.0",
+    "spatie/guzzle-rate-limiter-middleware": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.0"

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -10,6 +10,9 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use SellsyApi\Exception\OAuthException;
+use GuzzleHttp\HandlerStack;
+use Spatie\GuzzleRateLimiterMiddleware\RateLimiterMiddleware;
+
 
 class Request implements AsyncRequestInterface {
 
@@ -72,7 +75,10 @@ class Request implements AsyncRequestInterface {
             if (is_null($this->getEndPoint())) {
                 throw new \RuntimeException('endPoint is not set');
             }
-            $this->client = new Client(['base_uri' => $this->endPoint]);
+            $stack = HandlerStack::create();
+            $stack->push(RateLimiterMiddleware::perSecond(5));
+            $this->client = new Client(['base_uri' => $this->endPoint,
+                'handler' => $stack]);
         }
         return $this->client;
     }


### PR DESCRIPTION
Hi folks,

I did this pull request in order to support Sellsy API rate limit.
With this, you won't get anymore the "429 Too much request".

I hope it can help and you'll accept to merge this pull request.

Best rergards, 